### PR TITLE
FE-8 Build and push the docker image only if the branch is dev or master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,3 +37,8 @@ jobs:
             docker build -t draftapp/$IMAGE_NAME:$TAG .
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             docker push draftapp/$IMAGE_NAME:$TAG
+          filters:
+            branches:
+              only:
+                - dev
+                - master


### PR DESCRIPTION
- [x] You have followed our [**contributing guidelines**](https://github.com/react-boilerplate/react-boilerplate/blob/master/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev` 
- [ ] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Internal code generators and templates are updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Fixes: #10 
